### PR TITLE
Uses Jason json library rather than Poison

### DIFF
--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -67,7 +67,7 @@ defmodule ElixirAuthGoogle do
   """
   @spec get_token(String.t, Map) :: String.t
   def get_token(code, conn) do
-    body = Poison.encode!(
+    body = Jason.encode!(
       %{ client_id: System.get_env("GOOGLE_CLIENT_ID") || Application.get_env(:elixir_auth_google, :client_id),
          client_secret: System.get_env("GOOGLE_CLIENT_SECRET") || Application.get_env(:elixir_auth_google, :client_secret),
          redirect_uri: generate_redirect_uri(conn),
@@ -104,7 +104,7 @@ defmodule ElixirAuthGoogle do
     if body == nil do
       {:error, :no_body}
     else # make keys of map atoms for easier access in templates
-      {:ok, str_key_map} = Poison.decode(body)
+      {:ok, str_key_map} = Jason.decode(body)
       atom_key_map = for {key, val} <- str_key_map, into: %{},
         do: {String.to_atom(key), val}
       {:ok, atom_key_map}

--- a/lib/httpoison_mock.ex
+++ b/lib/httpoison_mock.ex
@@ -12,10 +12,10 @@ defmodule ElixirAuthGoogle.HTTPoisonMock do
     {:error, :bad_request}
   end
 
- 
+
   # get/1 using a dummy _url to test body decoding.
   def get(_url) do
-    {:ok, %{body: Poison.encode!(
+    {:ok, %{body: Jason.encode!(
      %{
        email: "nelson@gmail.com",
        email_verified: true,
@@ -33,6 +33,6 @@ defmodule ElixirAuthGoogle.HTTPoisonMock do
   post/2 passing in dummy _url & _body to test return of access_token.
   """
   def post(_url, _body) do
-    {:ok, %{body: Poison.encode!(%{access_token: "token1"})}}
+    {:ok, %{body: Jason.encode!(%{access_token: "token1"})}}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule ElixirAuthGoogle.MixProject do
   defp deps do
     [
       {:httpoison, "~> 1.8.0"},
-      {:poison, "~> 5.0.0"},
+      {:jason, "~> 1.2"},
 
       # tracking test coverage
       {:excoveralls, "~> 0.14.1", only: [:test, :dev]},


### PR DESCRIPTION
Phoenix ships with Jason as standard (and not Poison), so use the existing json decoder/encoder library instead of introducing another dependancy